### PR TITLE
Updated Docker alias command

### DIFF
--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -14,7 +14,7 @@ gem install kamal
 ...otherwise, you can run a dockerized version via an alias (add this to your .bashrc or similar to simplify re-use). On macOS, use:
 
 ```sh
-alias kamal="docker run -it --rm -v '${PWD}:/workdir' -v '/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock' -e SSH_AUTH_SOCK='/run/host-services/ssh-auth.sock' -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/basecamp/kamal:latest"
+alias kamal='docker run -it --rm -v "${PWD}:/workdir" -v "/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock" -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/basecamp/kamal:latest'
 ```
 
 Then, inside your app directory, run `kamal init`. Now edit the new file `config/deploy.yml`. It could look as simple as this:


### PR DESCRIPTION
Given `.bashrc` / `.zshrc` files are normally stored in the home fodler (`~`) folder, the `$PWD` variable becomes `~` even if the alias is called from another folder. Wrapping the alias command in single quotes avoids this premature expansion of the variable.