### PR TITLE
Create Guides section

### DIFF
--- a/_docs/guides.md
+++ b/_docs/guides.md
@@ -1,0 +1,61 @@
+---
+title: Guides & Tutorials
+order: 5
+---
+
+# Guides & Tutorials
+
+Most of the configurations are the same, here are few examples that you can adapt according to your needs.
+
+## Common accessories configurations
+
+### PostgreSQL
+
+```yml
+accessories:
+  db:
+    image: postgres:15
+    host: 192.168.0.1
+    port: 5432:5432
+    env:
+      secret:
+        - DATABASE_URL
+    files:
+      - config/init.sql:/docker-entrypoint-initdb.d/setup.sql
+    directories:
+      - data:/var/lib/postgresql/data
+```
+
+With `config/init.sql` as:
+```sql
+--  config/init.sql
+CREATE DATABASE myapp_production;
+```
+
+### MySQL
+
+```yml
+accessories:
+  db:
+    image: mysql:5.7
+    host: 192.168.0.1
+    port: 3306:3306
+    env:
+      clear:
+        MYSQL_ROOT_HOST: '%'
+      secret:
+        - MYSQL_ROOT_PASSWORD
+    directories:
+      - data:/var/lib/mysql
+```
+
+### Redis
+
+```yml
+accessories:
+  redis:
+    image: redis:latest
+    port: 6379:6379
+    volumes:
+      - cache:/data
+```


### PR DESCRIPTION
## Why? 

Because most of configuration are the same and I think it might help lot of developer to be getting on board with these few exemples and we could add some in the future.

I put few accessories examples here, but we could add some `Dockerfile`, `cmd` on hosts (like `bundle exec sidekiq`), Traefik configurations and so on.

## Preview 🚀

Here is what it looks like:
<img width="1428" alt="guides" src="https://github.com/basecamp/kamal-site/assets/8252238/d2a0d46a-7e3e-415b-a11a-d3c2a676ea0d">




Inspired by https://github.com/basecamp/kamal-site/pull/32

