### PR TITLE
updated options cpu counts

### DIFF
--- a/_docs/configuration.md
+++ b/_docs/configuration.md
@@ -330,11 +330,10 @@ servers:
       - 192.168.0.4
     cmd: bin/jobs
     options:
-      cap-add: true
-      cpu-count: 4
+      cpus: 4
 ```
 
-That'll start the job containers with `docker run ... --cap-add --cpu-count 4 ...`.
+That'll start the job containers with `docker run ... --cpus 4 ...`.
 
 ## Setting a minimum version
 


### PR DESCRIPTION
```yml
  job:
    hosts:
      - 123.123.123.123
    cmd: bundle exec sidekiq
    # Limit workers resources
   options:
      cap-add: true
      cpu-count: 2
```

raises:
```docker: Error response from daemon: invalid CapAdd: unknown capability: "CAP_--CPU-COUNT"```

We should use `cpus`

```yml
  job:
    hosts:
      - 123.123.123.123
    cmd: bundle exec sidekiq
    # Limit workers resources
   options:
     cpus: 4
```