### PR TITLE
Accessories need to be booted before they can be started

### DIFF
--- a/_docs/configuration.md
+++ b/_docs/configuration.md
@@ -647,7 +647,7 @@ The hosts that the accessories will run on can be specified by hosts or roles:
       - jobs
 ```
 
-Now run `kamal accessory start mysql` to start the MySQL server on 1.1.1.3. See `kamal accessory` for all the commands possible.
+Now run `kamal accessory boot mysql` to start the MySQL server on 1.1.1.3. See `kamal accessory` for all the commands possible.
 
 Accessory images must be public or tagged in your private registry.
 


### PR DESCRIPTION
Running `kamal accessory start mysql` with a new accessory will return an error:

```
docker stderr: Error response from daemon: No such container: hey-db
Error: failed to start containers: hey-db
```

Instead we should have people boot their container first via `kamal accessory boot mysql`w.