### PR TITLE
Remove newline in GCP config

### DIFF
--- a/_docs/configuration.md
+++ b/_docs/configuration.md
@@ -127,7 +127,7 @@ To sign into Artifact Registry, you would need to [create a service account](htt
 Once the service account is ready, you need to generate and download a JSON key, base64 encode it and add to `.env`:
 
 ```bash
-echo "KAMAL_REGISTRY_PASSWORD=$(base64 -i /path/to/key.json)" >> .env
+echo "KAMAL_REGISTRY_PASSWORD=$(base64 -i /path/to/key.json)" | tr -d "\\n"  >> .env
 ```
 
 Use the env variable as `password` along with `_json_key_base64` as `username`. 


### PR DESCRIPTION

Dotenv only captures the first line unless there are double quotes and then it still preserves the newlines since 3.0 https://github.com/bkeepers/dotenv?tab=readme-ov-file#multi-line-values