### PR TITLE
Update docs regarding shell expansion.

### DIFF
--- a/_docs/configuration.md
+++ b/_docs/configuration.md
@@ -346,11 +346,11 @@ servers:
 
 ## Using shell expansion
 
-You can use shell expansion to interpolate values from the host machine into labels with the `${}` syntax. Anything within the curly braces will be executed on the host machine and the result will be interpolated into the label.
+You can use shell expansion to interpolate values from the host machine into labels with the `$()` syntax. Anything within the parentheses will be executed on the host machine and the result will be interpolated into the label.
 
 ```yaml
 labels:
-  host-machine: "${cat /etc/hostname}"
+  host-machine: "$(cat /etc/hostname)"
 ```
 
 **Note:** Any other occurrence of `$` will be escaped to prevent unwanted shell expansion!


### PR DESCRIPTION
Update docs regarding shell expansion using curly braces {} instead of parentheses ().

See https://github.com/basecamp/kamal-site/issues/34