### PR TITLE
Bump kamal version in header to 1.4.0

### DIFF
--- a/_data/github.yml
+++ b/_data/github.yml
@@ -1,3 +1,3 @@
 ---
-tag_name: v1.3.1
-published_at: January 10, 2024
+tag_name: v1.4.0
+published_at: March 20, 2024


### PR DESCRIPTION
Not sure if there's an automated way of doing this.
But here's a PR to bump the version to the latest tagged version of Kamal.
<img width="1136" alt="image" src="https://github.com/basecamp/kamal-site/assets/9297340/e4bc5c17-a450-4da6-b1b2-9d2f396d888d">
