### PR TITLE
Keep links relative to index to stay in /hooks/ namespace

### DIFF
--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -25,12 +25,12 @@ If the script returns a non-zero exit code the command will be aborted.
 - `KAMAL_ROLE` — *Optional:* Role targeted, e.g. "web"
 
 The available hooks are
-- [docker-setup](../docker-setup)
-- [pre-connect](../pre-connect)
-- [pre-build](../pre-build)
-- [pre-deploy](../pre-deploy)
-- [post-deploy](../post-deploy)
-- [pre-traefik-reboot](../pre-traefik-reboot)
-- [post-traefik-reboot](../post-traefik-reboot)
+- [docker-setup](docker-setup)
+- [pre-connect](pre-connect)
+- [pre-build](pre-build)
+- [pre-deploy](pre-deploy)
+- [post-deploy](post-deploy)
+- [pre-traefik-reboot](pre-traefik-reboot)
+- [post-traefik-reboot](post-traefik-reboot)
 
 You can pass `--skip_hooks` to avoid running the hooks.


### PR DESCRIPTION
Fixes #65 