### PR TITLE
docs(command-server): fix typo `if` to `it`

### DIFF
--- a/docs/commands/server.md
+++ b/docs/commands/server.md
@@ -6,7 +6,7 @@ title: Server
 
 You can run `kamal server bootstrap` to setup docker on your hosts.
 
-If will check if docker is installed and if not it will attempt to install it via https://get.docker.com/.
+It will check if docker is installed and if not it will attempt to install it via https://get.docker.com/.
 
 ```bash
 $ kamal server


### PR DESCRIPTION
Fixing typo on docs (https://kamal-deploy.org/docs/commands/server/)

![image](https://github.com/basecamp/kamal-site/assets/53980548/2f85160e-80ce-4c22-8ba1-3fd881c76b8a)