### PR TITLE
Add log_lines to default healthz check example

### DIFF
--- a/docs/configuration/healthchecks.md
+++ b/docs/configuration/healthchecks.md
@@ -14,6 +14,7 @@ healthcheck:
   port: 4000
   max_attempts: 7
   interval: 20s
+  log_lines: 100
 ```
 
 This will ensure your application is configured with a traefik label for the healthcheck against `/healthz` and that the pre-deploy healthcheck that Kamal performs is done against the same path on port 4000.
@@ -40,7 +41,7 @@ The healthcheck allows for an optional `max_attempts` setting, which will attemp
 
 The HTTP health checks assume that the `curl` command is available inside the container. If that's not the case, use the healthcheck's `cmd` option to specify an alternative check that the container supports.
 
-When starting container healthcheck by default will only show last 50 lines. That might be not enough when something goes wrong - so you can add `log_lines` params and specify larger number if required.
+When starting the container healthcheck by default it only shows the last 50 lines. That might not be enough when something goes wrong - so you can add a `log_lines` setting and specify a larger number if required.
 
 ## [Zero-downtime deploy with cord files](#zero-downtime-deploy-with-cord-files)
 


### PR DESCRIPTION
The `log_lines` option comes up quite often on Discord and on GitHub discussions, it's currently just mentioned in the very last healthchecks paragraph which gets missed. 

Since we're using `interval` in the example which is also mentioned at the end of this section I added a mention of `log_lines` within that first custom example. 