### PR TITLE
Mention `KAMAL_VERSION` container environment variable

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -121,6 +121,7 @@ env:
 
 ## [Using Kamal env variables](#using-kamal-env-variables)
 
-The following env variables are set when your container runs:
+The following env variables are set in your container when it runs:
 
-`KAMAL_CONTAINER_NAME`: this contains the current container name and version
+- `KAMAL_CONTAINER_NAME`: the name of the container
+- `KAMAL_VERSION`: the current app version


### PR DESCRIPTION
The `KAMAL_VERSION` environment variable [is made available within the container](https://github.com/basecamp/kamal/blob/v1.5.2/lib/kamal/commands/app.rb#L20), but this was not documented, with `KAMAL_VERSION` only being mentioned [in the context of the hooks' environment variables](https://github.com/basecamp/kamal-site/blob/f66341197fa6329057f7836f7ba3240d6424e115/docs/hooks/hooks-overview.md?plain=1#L20).