### PR TITLE
Update Hooks Documentation to Include Filename Requirement

### DIFF
--- a/docs/hooks/hooks-overview.md
+++ b/docs/hooks/hooks-overview.md
@@ -35,3 +35,5 @@ The available hooks are:
 - [post-traefik-reboot](../post-traefik-reboot)
 
 You can pass `--skip_hooks` to avoid running the hooks.
+
+**Note:** The hook filename must be the hook name without any extension. For example, the [pre-deploy](../pre-deploy) hook should be named "pre-deploy" (without any file extension such as .sh or .rb).


### PR DESCRIPTION
My team was trying to use hooks with a `.sh` extension. Adding this clarification might help other users avoid similar problems.

![image](https://github.com/basecamp/kamal-site/assets/98332014/18389d08-6fc2-49f7-9d8b-71fac8889374)
