### PR TITLE
Fix page not found when visiting configuration index

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /docs/configuration/configuration-overview/
+---


### PR DESCRIPTION
While on `Installation` (https://kamal-deploy.org/docs/installation/) page, when clicking the `Next (Configuration)` link, it should should the `Configuration overview` page. But, instead, it shows a not found page.

This PR adds an index file to redirect to the "Configuration Overview" page.