### PR TITLE
Mention KAMAL_SERVICE in hooks overview

### DIFF
--- a/docs/hooks/hooks-overview.md
+++ b/docs/hooks/hooks-overview.md
@@ -16,6 +16,7 @@ If the script returns a non-zero exit code the command will be aborted.
 
 - `KAMAL_RECORDED_AT` — UTC timestamp in ISO 8601 format, e.g. `2023-04-14T17:07:31Z`
 - `KAMAL_PERFORMER` — The local user performing the command (from `whoami`)
+- `KAMAL_SERVICE` — The service name, e.g. app
 - `KAMAL_SERVICE_VERSION` — An abbreviated service and version for use in messages, e.g. app@150b24f
 - `KAMAL_VERSION` — The full version being deployed
 - `KAMAL_HOSTS` — A comma-separated list of the hosts targeted by the command


### PR DESCRIPTION
Update site to mention ENV['KAMAL_SERVICE'] is now available within the hooks.

Related PR: https://github.com/basecamp/kamal/pull/868