### PR TITLE
Add a note in `kamal build` about `#git_archive?`

### DIFF
--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -6,7 +6,7 @@ title: Build
 
 Build your app images and push them to your servers. These commands are called indirectly by `kamal deploy` and `kamal redeploy`.
 
-Kamal will, by default, only build files that you have committed to git. It's possible to configure kamal to use the current context (instead of a git archive of HEAD) by settings the [build context](https://kamal-deploy.org/docs/configuration/builders/#build-context).
+By default, Kamal will only build files you have committed to your git repository. However, you can configure Kamal to use the current context (instead of a git archive of HEAD) by setting the [build context](https://kamal-deploy.org/docs/configuration/builders/#build-context).
 
 ```bash
 $ kamal build

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -6,6 +6,8 @@ title: Build
 
 Build your app images and push them to your servers. These commands are called indirectly by `kamal deploy` and `kamal redeploy`.
 
+Kamal will, by default, only build files that you have committed to git. It's possible to configure kamal to use the current context (instead of a git archive of HEAD) by settings the [build context](https://kamal-deploy.org/docs/configuration/builders/#build-context).
+
 ```bash
 $ kamal build
 Commands:


### PR DESCRIPTION
This mentions that Kamal will, by default, only build code committed to git. And also how to override this. This closes https://github.com/basecamp/kamal-site/issues/96.