### PR TITLE
Documentation for custom SSL certificates

### DIFF
--- a/docs/configuration/proxy.md
+++ b/docs/configuration/proxy.md
@@ -50,6 +50,13 @@ Defaults to false:
   ssl: true
 ```
 
+In the scenario where Let's Encrypt is not an option, or you already have your own certificates from a different Certificate Authority, you can configure kamal-proxy to load the certificate and the corresponding private key from disk:
+
+```yaml
+  ssl_certificate_path: /data/cert/foo.example.com/fullchain.pem
+  ssl_private_key_path: /data/cert/foo.example.com/privkey.pem
+```
+
 ## [Response timeout](#response-timeout)
 
 How long to wait for requests to complete before timing out, defaults to 30 seconds:


### PR DESCRIPTION
Following the [change in kamal-proxy](https://github.com/basecamp/kamal-proxy/pull/17) and [a corresponding change in kamal](https://github.com/basecamp/kamal/pull/969), this MR adds documentation for the configuration option to load custom SSL certificate and the corresponding private key from disk:

<img width="1162" alt="image" src="https://github.com/user-attachments/assets/0a78798b-2b22-4130-8cda-6ea395831547">
