### PR TITLE
Adds multiple hosts documentation

### DIFF
--- a/assets/css/style-v2.scss
+++ b/assets/css/style-v2.scss
@@ -1,0 +1,20 @@
+---
+---
+
+@charset 'utf-8';
+
+@import 'base/reset';
+@import 'base/root';
+@import 'base/fonts';
+@import 'base/elements';
+@import 'base/button';
+@import 'base/rouge';
+
+@import 'modules/footer';
+@import 'modules/header';
+@import 'modules/headline';
+@import 'modules/intro';
+@import 'modules/nav';
+@import 'modules/page';
+@import 'modules/search';
+@import 'modules/video';

--- a/docs/configuration/proxy.md
+++ b/docs/configuration/proxy.md
@@ -27,6 +27,11 @@ If no hosts are set, then all requests will be forwarded, except for matching re
 ```yaml
   host: foo.example.com
 ```
+If multiple hosts are needed, these can be specified by comma separating the hosts.
+
+```yaml
+  host: foo.example.com,bar.example.com
+```
 
 ## [App port](#app-port)
 


### PR DESCRIPTION
This PR adds an example of specifying multiple hosts within the proxy host field.

ref: https://github.com/basecamp/kamal-proxy/issues/14