### PR TITLE
Update docs with correct secret file paths for destination-specific secrets

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -22,7 +22,7 @@ env:
 
 Kamal uses dotenv to automatically load environment variables set in the `.kamal/secrets` file.
 
-If you are using destinations, secrets will instead be read from `.kamal/secrets-<DESTINATION>` if it exists.
+If you are using destinations, secrets will instead be read from `.kamal/secrets.<DESTINATION>` if it exists.
 
 Common secrets across all destinations can be set in `.kamal/secrets-common`.
 

--- a/docs/upgrading/secrets-changes.md
+++ b/docs/upgrading/secrets-changes.md
@@ -6,7 +6,7 @@ title: Secrets changes
 
 Secrets have moved from `.env`/`.env.rb` to `.kamal/secrets.`
 
-If you are using destinations, secrets will be read from `.kamal/secrets-<DESTINATION>` first or `.kamal/secrets` if it is not found.
+If you are using destinations, secrets will be read from `.kamal/secrets.<DESTINATION>` first or `.kamal/secrets` if it is not found.
 
 ## [Interpolating secrets](#interpolating-secrets)
 


### PR DESCRIPTION
Destination-specific secret files are actually looked up with a dot prefix (e.g., `secrets.production`) instead of a hyphen prefix (e.g., `secrets-production`, as currently pointed out in the docs), according to https://github.com/basecamp/kamal/blob/8c32e6af07356031ffbad2e8eb60169904bc5e52/lib/kamal/secrets.rb#L10