### PR TITLE
Better readability & avoid copy-paste problems

### DIFF
--- a/docs/upgrading/secrets-changes.md
+++ b/docs/upgrading/secrets-changes.md
@@ -4,7 +4,7 @@ title: Secrets changes
 
 # Kamal 2: Secrets changes
 
-Secrets have moved from `.env`/`.env.rb` to `.kamal/secrets.`
+Secrets have moved from `.env`/`.env.rb` to `.kamal/secrets`.
 
 If you are using destinations, secrets will be read from `.kamal/secrets-<DESTINATION>` first or `.kamal/secrets` if it is not found.
 


### PR DESCRIPTION
Minor change, just moving the dots out of the code clock

Before
<img width="718" alt="image" src="https://github.com/user-attachments/assets/e4bef8e5-37d7-427e-9352-1e761beea392">
After
<img width="566" alt="image" src="https://github.com/user-attachments/assets/096662a2-aa25-4e8b-86bc-ef34ec40d848">
