### PR TITLE
Document `secrets.destination` as per code

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -22,7 +22,7 @@ env:
 
 Kamal uses dotenv to automatically load environment variables set in the `.kamal/secrets` file.
 
-If you are using destinations, secrets will instead be read from `.kamal/secrets-<DESTINATION>` if it exists.
+If you are using destinations, secrets will instead be read from `.kamal/secrets.<DESTINATION>` if it exists.
 
 Common secrets across all destinations can be set in `.kamal/secrets-common`.
 

--- a/docs/upgrading/secrets-changes.md
+++ b/docs/upgrading/secrets-changes.md
@@ -6,7 +6,7 @@ title: Secrets changes
 
 Secrets have moved from `.env`/`.env.rb` to `.kamal/secrets.`
 
-If you are using destinations, secrets will be read from `.kamal/secrets-<DESTINATION>` first or `.kamal/secrets` if it is not found.
+If you are using destinations, secrets will be read from `.kamal/secrets.<DESTINATION>` first or `.kamal/secrets` if it is not found.
 
 ## [Interpolating secrets](#interpolating-secrets)
 


### PR DESCRIPTION
Fixes https://github.com/basecamp/kamal/issues/984.
Alternative fix: https://github.com/basecamp/kamal/pull/983.

### Details

Document `.kamal/secrets.destination` instead of `.kamal/secrets-destination`, to reflect actual code behavior.