### PR TITLE
Fix broken link in upgrade guide

### DIFF
--- a/docs/upgrading/secrets-changes.md
+++ b/docs/upgrading/secrets-changes.md
@@ -23,7 +23,7 @@ SECRET_FROM_ENV=$SECRET_FROM_ENV
 SECRET_FROM_COMMAND=$(op read ...)
 ```
 
-See [here](../configuration/environment-variables#using-kamal-secrets) for more details
+See [here](../configuration/environment-variables#secrets) for more details
 
 ## [Environment variables in deploy.yml](#environment-variables-in-deployyml)
 


### PR DESCRIPTION
The link in the following section is broken

https://kamal-deploy.org/docs/upgrading/secrets-changes/#interpolating-secrets

![image](https://github.com/user-attachments/assets/e1bb2b80-af1e-48a4-baa9-85cc61789213)

