### PR TITLE
Corrects broken links on the site

### DIFF
--- a/docs/commands/proxy.md
+++ b/docs/commands/proxy.md
@@ -25,7 +25,7 @@ When you want to upgrade kamal-proxy, you can call `kamal proxy reboot`. This is
 
 You can use a rolling reboot with `kamal proxy reboot --rolling` to avoid restarting on all servers simultaneously.
 
-You can also use [pre-proxy-reboot](../hooks/pre-proxy-reboot) and [post-proxy-reboot](../hooks/post-proxy-reboot) hooks to remove and add the servers to upstream load balancers as you reboot them.
+You can also use [pre-proxy-reboot](../../hooks/pre-proxy-reboot) and [post-proxy-reboot](../../hooks/post-proxy-reboot) hooks to remove and add the servers to upstream load balancers as you reboot them.
 
 ## Boot configuration
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -33,7 +33,7 @@ KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
 RAILS_MASTER_KEY=$(cat config/master.key)
 ```
 
-You can also use [secret helpers](../commands/secrets) for some common password managers.
+You can also use [secret helpers](../../commands/secrets) for some common password managers.
 
 ```
 SECRETS=$(kamal secrets fetch ...)

--- a/docs/upgrading/configuration-changes.md
+++ b/docs/upgrading/configuration-changes.md
@@ -6,7 +6,7 @@ title: Configuration changes
 
 ## [Builder](#builder)
 
-The [builder configuration](../configuration/builders) has been simplified.
+The [builder configuration](../../configuration/builders) has been simplified.
 
 ### Arch
 

--- a/docs/upgrading/secrets-changes.md
+++ b/docs/upgrading/secrets-changes.md
@@ -23,7 +23,7 @@ SECRET_FROM_ENV=$SECRET_FROM_ENV
 SECRET_FROM_COMMAND=$(op read ...)
 ```
 
-See [here](../configuration/environment-variables#using-kamal-secrets) for more details
+See [here](../../configuration/environment-variables#using-kamal-secrets) for more details
 
 ## [Environment variables in deploy.yml](#environment-variables-in-deployyml)
 

--- a/v1/docs/configuration/environment-variables.md
+++ b/v1/docs/configuration/environment-variables.md
@@ -29,7 +29,7 @@ KAMAL_REGISTRY_PASSWORD=pw
 DB_PASSWORD=secret123
 ```
 
-See [Envify](/docs/commands/envify/) for how to use generated .env files.
+See [Envify](../../commands/envify/) for how to use generated .env files.
 
 To pass the secrets you should list them under the `secret` key. When you do this the other variables need to be moved under the `clear` key.
 


### PR DESCRIPTION
Corrects the following broken links:
```
../hooks/pre-proxy-reboot > ../../hooks/pre-proxy-reboot
../hooks/post-proxy-reboot > ../../hooks/post-proxy-reboot
../commands/secrets > ../../commands/secrets
../configuration/builders > ../../configuration/builders
../configuration/environment-variables[...] > ../../configuration/environment-variables[...]
/docs/commands/envify/ > ../../commands/envify/
```