### PR TITLE
Remove `run_directory` documentation

### DIFF
--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -169,14 +169,6 @@ How long to wait for a containers to drain, default 30:
 drain_timeout: 10
 ```
 
-## [Run directory](#run-directory)
-
-Directory to store kamal runtime files in on the host, default `.kamal`.
-
-```yaml
-run_directory: /etc/kamal
-```
-
 ## [SSH options](#ssh-options)
 
 See [SSH](../ssh):


### PR DESCRIPTION
The support for configuring the `run_directory` has been dropped in the switch from Traefik to kamal-proxy, with this commit: https://github.com/basecamp/kamal/pull/940/commits/27a7b339a6fadda1614fd2a8c3903d3c1d54038c    

    