### PR TITLE
Revert "Documentation for custom SSL certificates"

### DIFF
--- a/docs/configuration/proxy.md
+++ b/docs/configuration/proxy.md
@@ -50,13 +50,6 @@ Defaults to false:
   ssl: true
 ```
 
-In the scenario where Let's Encrypt is not an option, or you already have your own certificates from a different Certificate Authority, you can configure kamal-proxy to load the certificate and the corresponding private key from disk:
-
-```yaml
-  ssl_certificate_path: /data/cert/foo.example.com/fullchain.pem
-  ssl_private_key_path: /data/cert/foo.example.com/privkey.pem
-```
-
 ## [Response timeout](#response-timeout)
 
 How long to wait for requests to complete before timing out, defaults to 30 seconds:


### PR DESCRIPTION
Reverts basecamp/kamal-site#100, as this change has not landed yet.