### PR TITLE
Mention new container port on upgrade overview

### DIFF
--- a/docs/upgrading/overview.md
+++ b/docs/upgrading/overview.md
@@ -56,6 +56,10 @@ $ kamal config -d beta
 
 Follow the steps [here](../secrets-changes).
 
+### Verify container port
+
+The default app port was [changed from 3000 to 80](https://kamal-deploy.org/docs/upgrading/configuration-changes/#traefik-to-proxy), you'll need to either specify your `app_port` or update your `EXPOSE` port if not using port 80.
+
 ## [In-place upgrades](#in-place-upgrades)
 
 **Warning: Test this in a non-production environment first, if possible.**


### PR DESCRIPTION
The new app listening port setting is a bit difficult to find, it'd be great to mention the change on the upgrade overview instructions. Seeing quite a few discussions on Discord about their app failing to boot when upgrading and this is one of the most common issues coming up.