### PR TITLE
Correct documentation for shared secrets with destinations

### DIFF
--- a/docs/upgrading/secrets-changes.md
+++ b/docs/upgrading/secrets-changes.md
@@ -6,7 +6,7 @@ title: Secrets changes
 
 Secrets have moved from `.env`/`.env.rb` to `.kamal/secrets`.
 
-If you are using destinations, secrets will be read from `.kamal/secrets.<DESTINATION>` first or `.kamal/secrets` if it is not found.
+If you are using destinations, secrets will be read from `.kamal/secrets.<DESTINATION>` first or `.kamal/secrets-common` if it is not found.
 
 ## [Interpolating secrets](#interpolating-secrets)
 


### PR DESCRIPTION
On this [documentation page](https://kamal-deploy.org/docs/upgrading/secrets-changes/), the documentation references `.kamal/secrets` as the common shared secret file but `.kamal/secrets-common` is the shared file instead.

I assumed `.kamal/secrets-common` is the correct behaviour from this pull request: https://github.com/basecamp/kamal/pull/933

BEFORE

![CleanShot 2024-10-06 at 16 18 16@2x](https://github.com/user-attachments/assets/50b226d0-9e9e-4255-bc5f-3ec901d85406)

AFTER

![CleanShot 2024-10-06 at 16 25 13@2x](https://github.com/user-attachments/assets/306e05f2-327f-4748-97fa-77d081fb5ad0)


