### PR TITLE
Add Docker Mount of SSH hidden directory to docker installation for M…

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -15,7 +15,7 @@ Otherwise, you can run a dockerized version via an alias (add this to your `~/.b
 On macOS, use:
 
 ```sh
-alias kamal='docker run -it --rm -v "${PWD}:/workdir" -v "/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock" -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/basecamp/kamal:latest'
+alias kamal='docker run -it --rm -v "${PWD}:/workdir" -v "/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock" -v "$HOME/.ssh:/root/.ssh" -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/basecamp/kamal:latest'
 ```
 
 On Linux, use:


### PR DESCRIPTION
As per this issue here: https://github.com/basecamp/kamal/issues/218

This exposes the hidden `.ssh` directory to the docker container. Solved by @gioggi and @stewones. I spent at least 1 hour banging my head wondering why my ssh auth wasn't working. I forgot I was using a Docker container and it wasn't exposing my Mac's SSH keys, I found the linked GitHub issue that made me aware of the issue.

I am happy to discuss any changes.