### PR TITLE
Fix wrong flag used in aliases docs for container reuse

### DIFF
--- a/docs/configuration/aliases.md
+++ b/docs/configuration/aliases.md
@@ -11,14 +11,14 @@ Aliases are shortcuts for Kamal commands.
 For example, for a Rails app, you might open a console with:
 
 ```shell
-kamal app exec -i -r "rails console"
+kamal app exec -i --reuse "rails console"
 ```
 
 By defining an alias, like this:
 
 ```yaml
 aliases:
-  console: app exec -r -i "rails console"
+  console: app exec --reuse -i "rails console"
 ```
 
 You can now open the console with:


### PR DESCRIPTION
Got tripped up on this for a minute, and realized that `-r` is for roles, and `--reuse` has no short flag