### PR TITLE
Add info about default public images at docker hub

### DIFF
--- a/docs/configuration/docker-registry.md
+++ b/docs/configuration/docker-registry.md
@@ -8,6 +8,8 @@ title: Registry
 
 The default registry is Docker Hub, but you can change it using `registry/server`.
 
+By default, Docker Hub creates public repositories. To avoid making your images public, set up a private repository before deploying, or change the default repository privacy settings to private in your [Docker Hub settings](https://hub.docker.com/repository-settings/default-privacy).
+
 A reference to a secret (in this case, `DOCKER_REGISTRY_TOKEN`) will look up the secret
 in the local environment:
 


### PR DESCRIPTION
I made this PR as result of [discussion](https://github.com/basecamp/kamal/discussions/1128).

Docker hub by default creates publicly available docker images and some uses may accidentally make their images public. 