### PR TITLE
Add a small note that enabling `ssl: true` makes `kamal-proxy` stop forwarding headers unless `forward_headers` is also set to `true`

### DIFF
--- a/docs/configuration/proxy.md
+++ b/docs/configuration/proxy.md
@@ -67,6 +67,8 @@ Defaults to `false`:
   ssl: true
 ```
 
+If you set `ssl` to `true`, `kamal-proxy` will stop forwarding headers to your app, unless you explicitly set `forward_headers: true`, as documented in [Forward Headers](#forward-headers).
+
 ## [Response timeout](#response-timeout)
 
 How long to wait for requests to complete before timing out, defaults to 30 seconds:


### PR DESCRIPTION
This is especially important in the case you're putting your Rails app behind Cloudflare, and are using the `cloudflare-rails` gem to get the real user `request.remote_ip`. Without this option, gems like `cloudflare-rails` will fail to set the right headers and infer the right request IP as discussed in modosc/cloudflare-rails#165