### PR TITLE
Update cron docs

### DIFF
--- a/docs/configuration/cron.md
+++ b/docs/configuration/cron.md
@@ -12,7 +12,7 @@ servers:
     hosts:
       - 192.168.0.1
     cmd:
-      bash -c "cat config/crontab | crontab - && cron -f"
+      bash -c "(env && cat config/crontab) | crontab - && cron -f"
 ```
 
-This assumes that the Cron settings are stored in `config/crontab`.
+This assumes that the Cron settings are stored in `config/crontab`. Cron does not automatically propagate environment variables, the example above copies them into the crontab.


### PR DESCRIPTION
Change the example to copy environment variables when installing crontab, it was a source of headaches for me because cron does not give any feedback about it.