### PR TITLE
Add a full example of using yml anchors

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -11,6 +11,8 @@
       url: /docs/configuration/accessories/
     - title: "Aliases"
       url: /docs/configuration/aliases/
+    - title: "Anchors"
+      url: /docs/configuration/anchors/
     - title: "Booting"
       url: /docs/configuration/booting/
     - title: "Builders"

--- a/docs/configuration/anchors.md
+++ b/docs/configuration/anchors.md
@@ -1,0 +1,30 @@
+---
+title: Anchors
+---
+
+# Anchors
+
+You can re-use parts of your Kamal configuration by defining them as anchors and referencing them with aliases.
+
+For example, you might need to define a shared healthcheck for multiple worker roles. Anchors
+begin with `x-` and are defined at the root level of your deploy.yml file.
+
+```yaml
+x-worker-healthcheck: &worker-healthcheck
+  health-cmd: bin/worker-healthcheck
+  health-start-period: 5s
+  health-retries: 5
+  health-interval: 5s
+```
+
+To use this anchor in your deploy configuration, reference it via the alias.
+
+```yaml
+servers:
+  worker:
+    hosts:
+      - 867.53.0.9
+    cmd: bin/jobs
+    options:
+      <<: *worker-healthcheck
+```

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -16,7 +16,7 @@ e.g., `kamal deploy -d staging`.
 In this case, the configuration will also be read from `config/deploy.staging.yml`
 and merged with the base configuration.
 
-## [Extensions](#extensions)
+## [Anchors](#anchors)
 
 Kamal will not accept unrecognized keys in the configuration file.
 
@@ -24,7 +24,7 @@ However, you might want to declare a configuration block using YAML anchors
 and aliases to avoid repetition.
 
 You can prefix a configuration section with `x-` to indicate that it is an
-extension. Kamal will ignore the extension and not raise an error.
+anchor. Kamal will ignore the anchor and not raise an error. See [Anchors](../anchors) for more information.
 
 ## [The service name](#the-service-name)
 


### PR DESCRIPTION
I was in the process of upgrading to Kamal 2 and needed to utilize the YML anchors functionality for a shared healthcheck across a handful of worker roles. I found the docs within the actual Kamal gem but thought it'd be helpful to have a full example on the site as well.

There is an "extensions" section on the configuration overview section but this makes me think that we're extending Kamal with additional functionality, we also mention YAML anchors here:

<img width="737" alt="image" src="https://github.com/user-attachments/assets/e358bd57-c34a-419f-9bc6-cbc0738a803d">

YML anchors/aliases are fairly common, it's also part of the YML spec. Should we just rename to `anchors` and reserve `extensions` for some possible extension/plugin system in the future? I can tweak the configuration overview section to call them anchors if so or I can just rename the anchors page to extensions. 
