### PR TITLE
Update Docker Registry Username Reference

### DIFF
--- a/docs/configuration/docker-registry.md
+++ b/docs/configuration/docker-registry.md
@@ -18,8 +18,7 @@ in the local environment:
 ```yaml
 registry:
   server: registry.digitalocean.com
-  username:
-    - DOCKER_REGISTRY_TOKEN
+  username: registry-user-name
   password:
     - DOCKER_REGISTRY_TOKEN
 ```

--- a/v1/docs/configuration/docker-registry.md
+++ b/v1/docs/configuration/docker-registry.md
@@ -11,8 +11,7 @@ A reference to secret (in this case DOCKER_REGISTRY_TOKEN) will look up the secr
 ```yaml
 registry:
   server: registry.digitalocean.com
-  username:
-    - DOCKER_REGISTRY_TOKEN
+  username: registry-user-name
   password:
     - DOCKER_REGISTRY_TOKEN
 ```


### PR DESCRIPTION
This PR fixes an issue with the Docker registry username in the configuration file. 

Previously, the registry doc refers to use `DOCKER_REGISTRY_TOKEN` as username for registry.