### PR TITLE
Fix digital ocean registry example

### DIFF
--- a/docs/configuration/docker-registry.md
+++ b/docs/configuration/docker-registry.md
@@ -12,14 +12,14 @@ By default, Docker Hub creates public repositories. To avoid making your images 
 set up a private repository before deploying, or change the default repository privacy
 settings to private in your [Docker Hub settings](https://hub.docker.com/repository-settings/default-privacy).
 
-A reference to a secret (in this case, `DOCKER_REGISTRY_TOKEN`) will look up the secret
+A reference to a secret (in this case, `DOCKER_REGISTRY_USERNAME` and `DOCKER_REGISTRY_TOKEN`) will look up the secret
 in the local environment:
 
 ```yaml
 registry:
   server: registry.digitalocean.com
   username:
-    - DOCKER_REGISTRY_TOKEN
+    - DOCKER_REGISTRY_USERNAME
   password:
     - DOCKER_REGISTRY_TOKEN
 ```


### PR DESCRIPTION
The DO registry uses your email address for the username, update example to reflect proper usage.

Related: https://github.com/basecamp/kamal/discussions/804

<img width="674" alt="image" src="https://github.com/user-attachments/assets/9589f2e4-b342-4ab4-84c9-c9aba748079e" />
