### PR TITLE
Switch directories and volume examples in accessories.md

### DIFF
--- a/docs/configuration/accessories.md
+++ b/docs/configuration/accessories.md
@@ -120,7 +120,7 @@ before being mounted:
 
 ```yaml
     directories:
-      - mysql-logs:/var/log/mysql
+      - /path/to/mysql-logs:/var/log/mysql
 ```
 
 ## [Volumes](#volumes)
@@ -130,7 +130,7 @@ They are not created or copied before mounting:
 
 ```yaml
     volumes:
-      - /path/to/mysql-logs:/var/log/mysql
+      - mysql-logs:/var/log/mysql
 ```
 
 ## [Network](#network)


### PR DESCRIPTION
This better matches how these are being used with Docker. The directories setting is passing in a directory from a path, while the volumes setting will create a docker volume with the given name.

---

The Volumes section also states:
"Any other volumes to mount, in addition to the files and directories. They are not created or copied before mounting:"

I wonder if this should also be updated to clarify that it will create the Docker volume if it doesn't exist.

Tat's the behavior I observed anyway. I switched from a directory mount to a volume for my database accessory's data and the Docker volume was created automatically.