### PR TITLE
Fix bitwarden secrets manager fetch secrets command

### DIFF
--- a/docs/commands/secrets.md
+++ b/docs/commands/secrets.md
@@ -103,7 +103,10 @@ Use the adapter 'bitwarden-sm':
 
 ```bash
 # Fetch all secrets that the machine account has access to
-kamal secrets fetch --adapter bitwarden-sm
+kamal secrets fetch --adapter bitwarden-sm all
+
+# Fetch secrets from a project
+kamal secrets fetch --adapter bitwarden-sm MyProjectID/all
 
 # Extract the secret
 kamal secrets extract REGISTRY_PASSWORD <SECRETS-FETCH-OUTPUT>


### PR DESCRIPTION
Added the missing `all` option to the "fetch all secrets" command and added the command to fetch secrets from a specific project that the machine account has access to.

Reported here: #166 