### PR TITLE
Pin Docker image to v1.9.2

### DIFF
--- a/v1/docs/installation/index.md
+++ b/v1/docs/installation/index.md
@@ -15,13 +15,13 @@ Otherwise, you can run a dockerized version via an alias (add this to your `~/.b
 On macOS, use:
 
 ```shell
-alias kamal='docker run -it --rm -v "${PWD}:/workdir" -v "/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock" -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/basecamp/kamal:latest'
+alias kamal='docker run -it --rm -v "${PWD}:/workdir" -v "/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock" -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/basecamp/kamal:v1.9.2'
 ```
 
 On Linux, use:
 
 ```shell
-alias kamal='docker run -it --rm -v "${PWD}:/workdir" -v "${SSH_AUTH_SOCK}:/ssh-agent" -v /var/run/docker.sock:/var/run/docker.sock -e "SSH_AUTH_SOCK=/ssh-agent" ghcr.io/basecamp/kamal:latest'
+alias kamal='docker run -it --rm -v "${PWD}:/workdir" -v "${SSH_AUTH_SOCK}:/ssh-agent" -v /var/run/docker.sock:/var/run/docker.sock -e "SSH_AUTH_SOCK=/ssh-agent" ghcr.io/basecamp/kamal:v1.9.2'
 ```
 
 Then, inside your app directory, run `kamal init`. Now edit the new file `config/deploy.yml`. It could look as simple as this:


### PR DESCRIPTION
Updates the Kamal Docker image from `latest` to `v1.9.2` to ensure consistent deployments with [the latest v1 release](https://github.com/basecamp/kamal/pkgs/container/kamal/284838200?tag=v1.9.2).