### PR TITLE
docs: Lightly improve the documentation of metrics_port

### DIFF
--- a/docs/configuration/proxy.md
+++ b/docs/configuration/proxy.md
@@ -206,9 +206,13 @@ These options are used when booting the proxy container.
 
 ```yaml
   run:
-    http_port: 8080                # HTTP port to use (default 80)
-    https_port: 8443               # HTTPS port to use (default 443)
-    metrics_port: 9090             # Port for Prometheus metrics
+    http_port: 8080                # HTTP port to use (default: 80)
+    https_port: 8443               # HTTPS port to use (default: 443)
+    metrics_port: 9090             # Where to find prometheus metrics in your application
+                                   #
+                                   # The proxy will make available on 127.0.0.1:(port)/metrics
+                                   # any metrics you are serving on application:(port)/metrics.
+                                   # (default: nil)
     debug: true                    # Debug logging (default: false)
     log_max_size: "30m"            # Maximum log file size (default: "10m")
     publish: false                 # Publish ports to the host (default: true)


### PR DESCRIPTION
I falsely believed that `metrics_port`, being on `run` next to http_port and not being at the top level next to `app_port`, meant it was proxy-level metrics, i.e. "how many things did kamal proxy process". This port is actually to do with the application and this is unclear.

I think clearing this up will help other people in future - there are a couple github disussions that would be cleaned up by this, too

q.v. https://github.com/basecamp/kamal/pull/1757