### PR TITLE
Document hook output, post-configure, external commands, and hook PATH

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -25,6 +25,8 @@
       url: /docs/configuration/docker-registry/
     - title: "Environment variables"
       url: /docs/configuration/environment-variables/
+    - title: "External commands"
+      url: /docs/configuration/external-commands/
     - title: "Logging"
       url: /docs/configuration/logging/
     - title: "Proxy"
@@ -97,6 +99,8 @@
   sections:
     - title: "Overview"
       url: /docs/hooks/overview/
+    - title: "pre-configure"
+      url: /docs/hooks/pre-configure/
     - title: "docker-setup"
       url: /docs/hooks/docker-setup/
     - title: "pre-connect"

--- a/docs/configuration/external-commands.md
+++ b/docs/configuration/external-commands.md
@@ -1,0 +1,68 @@
+---
+title: External commands
+---
+
+# External commands
+
+Kamal can be extended with external commands. When you run `kamal foo` and `foo` is not a built-in command or alias, Kamal looks for an external command to run instead.
+
+## [Lookup order](#lookup-order)
+
+1. **Project-local**: `.kamal/bin/foo` in the current working directory
+2. **System-wide**: `kamal-foo` anywhere on your `$PATH`
+
+The first match wins. If neither is found, Kamal reports the usual "Could not find command" error.
+
+## [Writing an external command](#writing-an-external-command)
+
+An external command is any executable file. Kamal replaces its own process with the command (`exec`), so it behaves as if you ran the script directly — no Kamal configuration is loaded, no hooks fire, no locks are acquired.
+
+```bash
+#!/bin/bash
+# .kamal/bin/claims — list destination leases
+echo "Active leases:"
+git for-each-ref refs/kamal/destinations/
+```
+
+```shell
+chmod +x .kamal/bin/claims
+kamal claims
+```
+
+Arguments after the command name are forwarded:
+
+```shell
+kamal claims release beta2   # runs: .kamal/bin/claims release beta2
+```
+
+## [Built-in commands take precedence](#built-in-commands-take-precedence)
+
+External commands never shadow built-in commands or aliases. If `deploy` is both a built-in and a `.kamal/bin/deploy`, the built-in always wins — even with unambiguous prefix matching (`kamal dep` resolves to `deploy`, not an external `dep`).
+
+## [System-wide commands](#system-wide-commands)
+
+Place a `kamal-<name>` executable on your `$PATH` to make it available across all projects:
+
+```shell
+# /usr/local/bin/kamal-dashboard
+#!/bin/bash
+open "https://dashboard.example.com"
+```
+
+```shell
+kamal dashboard   # opens the URL
+```
+
+Project-local commands (`.kamal/bin/`) take priority over system-wide commands with the same name.
+
+## [Hooks and .kamal/bin](#hooks-and-kamalbin)
+
+During [hook execution](/docs/hooks/overview/), `.kamal/bin` is prepended to `$PATH`. This means hooks can call project-local commands without specifying the full path:
+
+```bash
+#!/bin/bash
+# .kamal/hooks/post-deploy — calls .kamal/bin/notify directly
+notify "Deploy complete: $KAMAL_SERVICE_VERSION"
+```
+
+See [Hook PATH](/docs/hooks/overview/#hook-path) for details.

--- a/docs/hooks/overview.md
+++ b/docs/hooks/overview.md
@@ -24,9 +24,13 @@ If the script returns a non-zero exit code, the command will be aborted.
 - `KAMAL_SUBCOMMAND` — _Optional:_ The subcommand we are running
 - `KAMAL_DESTINATION` — _Optional:_ Destination, e.g., "staging"
 - `KAMAL_ROLE` — _Optional:_ Role targeted, e.g., "web"
+- `KAMAL_OUTPUT` — Path to the hook output file (see [Hook output](#hook-output) below)
+
+**Note:** The [pre-configure](../pre-configure) hook runs before configuration is created. Only `KAMAL_DESTINATION` and `KAMAL_OUTPUT` are available to that hook; the other variables listed above are set for all subsequent hooks.
 
 The available hooks are:
 
+- [pre-configure](../pre-configure)
 - [docker-setup](../docker-setup)
 - [pre-connect](../pre-connect)
 - [pre-build](../pre-build)
@@ -37,6 +41,43 @@ The available hooks are:
 - [pre-proxy-reboot](../pre-proxy-reboot)
 - [post-proxy-reboot](../post-proxy-reboot)
 
-You can pass `--skip_hooks` to avoid running the hooks.
+You can pass `--skip-hooks` to avoid running the hooks.
 
 **Note:** The hook filename must be the hook name without any extension. For example, the [pre-deploy](../pre-deploy) hook should be named "pre-deploy" (without any file extension such as .sh or .rb).
+
+## Hook output
+
+Hooks can pass data back to Kamal by writing `KEY=VALUE` lines (dotenv format) to the file at `$KAMAL_OUTPUT`:
+
+```bash
+#!/bin/bash
+echo "DEPLOY_SLOT=beta2" >> "$KAMAL_OUTPUT"
+echo "KAMAL_MESSAGE=Claimed beta slot 2" >> "$KAMAL_OUTPUT"
+```
+
+This is similar to GitHub Actions' `$GITHUB_OUTPUT`. Hooks that don't write to this file behave identically to before.
+
+### Special keys
+
+- `KAMAL_DESTINATION` — When written by the [pre-configure](../pre-configure) hook, sets or rewrites the deployment destination.
+- `KAMAL_MESSAGE` — Printed to the user after the hook completes, regardless of verbosity settings.
+
+### Accumulation across hooks
+
+Hook outputs accumulate across the deploy lifecycle. A `pre-deploy` hook that writes `DEPLOY_ID=123` makes `$DEPLOY_ID` available in the environment of subsequent hooks like `post-deploy`.
+
+### Precedence
+
+Hook outputs have the lowest precedence. They cannot override Kamal's built-in environment variables (`KAMAL_RECORDED_AT`, `KAMAL_VERSION`, etc.) or secrets.
+
+## Hook PATH
+
+When hooks execute, `.kamal/bin` is prepended to `$PATH` (if the directory exists). This means hooks can call project-local scripts by name without a full path:
+
+```bash
+#!/bin/bash
+# .kamal/hooks/post-deploy — calls .kamal/bin/notify directly
+notify "Deployed $KAMAL_SERVICE_VERSION to $KAMAL_DESTINATION"
+```
+
+The PATH is restored after each hook completes. See [External commands](/docs/configuration/external-commands/#hooks-and-kamalbin) for more on `.kamal/bin`.

--- a/docs/hooks/pre-configure.md
+++ b/docs/hooks/pre-configure.md
@@ -1,0 +1,37 @@
+---
+title: pre-configure
+---
+
+# Hooks: pre-configure
+
+Runs before configuration is created. This hook can inject or rewrite the deployment destination by writing `KAMAL_DESTINATION` to `$KAMAL_OUTPUT`.
+
+Because config has not been created yet, this hook only receives a minimal environment:
+
+- `KAMAL_DESTINATION` — the destination passed via `-d` (if any)
+- `KAMAL_OUTPUT` — path to the [hook output file](/docs/hooks/overview/#hook-output)
+
+The full set of `KAMAL_*` variables (hosts, roles, version, etc.) is not available to this hook.
+
+### Rewriting a destination
+
+If the hook writes `KAMAL_DESTINATION` to `$KAMAL_OUTPUT`, Kamal reconfigures with the new destination before proceeding. This is useful for dynamic destination assignment — for example, claiming an available beta slot:
+
+```bash
+#!/bin/bash
+SLOT=$(claim-beta-slot)  # .kamal/bin is on PATH during hooks
+echo "KAMAL_DESTINATION=${SLOT}" >> "$KAMAL_OUTPUT"
+echo "KAMAL_MESSAGE=Deploying to ${SLOT}" >> "$KAMAL_OUTPUT"
+```
+
+The `claim-beta-slot` script can live in `.kamal/bin/` — it will be on `$PATH` automatically during hook execution (see [Hook PATH](/docs/hooks/overview/#hook-path)).
+
+Running `kamal deploy -d beta` with the hook above would reconfigure the deploy to use the claimed slot (e.g., `deploy.beta2.yml`) instead of `deploy.beta.yml`.
+
+### Injecting a destination
+
+The hook can also inject a destination when none was provided on the command line. This works with [`require_destination`](/docs/configuration/overview/#require-destinations) — the hook supplies the destination before the requirement is checked.
+
+### Skipping
+
+Like all hooks, `pre-configure` is skipped when `--skip-hooks` is passed. It also does not fire for commands that don't load configuration (e.g., `kamal version`).


### PR DESCRIPTION
## Summary

Documentation for basecamp/kamal#1782, basecamp/kamal#1783, basecamp/kamal#1784, and basecamp/kamal#1785.

- New `docs/configuration/external-commands.md` page — `.kamal/bin/<name>` and `kamal-<name>` on PATH lookup, precedence, built-in shadowing prevention, hook PATH connection
- New `docs/hooks/post-configure.md` page — timing, available env vars, destination rewriting/injection examples, `require_destination` interaction
- Updated `docs/hooks/overview.md` — `KAMAL_OUTPUT` in env var list, new "Hook output" section (mechanism, special keys, accumulation, precedence), new "Hook PATH" section (`.kamal/bin` prepended to `$PATH` during hooks), `post-configure` in hooks list, fixed `--skip_hooks` → `--skip-hooks`
- Updated `_data/docs.yml` — `post-configure` in sidebar navigation, `External commands` in sidebar navigation

## Test plan

- [ ] Verify Jekyll build passes
- [ ] Verify external commands page renders at `/docs/configuration/external-commands/`
- [ ] Verify post-configure page renders at `/docs/hooks/post-configure/`
- [ ] Verify hook output and hook PATH anchor links work
- [ ] Verify sidebar shows External commands under Configuration and post-configure under Hooks