### PR TITLE
Clarify custom error page filenames

### DIFF
--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -130,7 +130,10 @@ secrets_path: /user_home/kamal/secrets
 ## [Error pages](#error-pages)
 
 A directory relative to the app root to find error pages for the proxy to serve.
-Any files in the format 4xx.html or 5xx.html will be copied to the hosts.
+Kamal copies any files matching `4??.html` or `5??.html` from this directory to the hosts.
+`kamal-proxy` looks up custom pages by exact status code, so include files like
+`404.html`, `500.html`, `502.html`, `503.html`, and `504.html` rather than only
+`4xx.html` or `5xx.html`.
 
 ```yaml
 error_pages_path: public


### PR DESCRIPTION
## Summary
- update the rendered configuration docs for `error_pages_path`
- clarify that Kamal copies `4??.html` and `5??.html` files from the configured directory
- make it explicit that `kamal-proxy` looks up custom error pages by exact status code

## Why
The current docs page implies that `4xx.html` or `5xx.html` are sufficient on their own, but `kamal-proxy` resolves custom error pages using exact status-code filenames.

Related source change: basecamp/kamal#1837