### PR TITLE
Document pre-connect hook re-entrancy/recursion risk

### DIFF
--- a/docs/hooks/overview.md
+++ b/docs/hooks/overview.md
@@ -37,6 +37,8 @@ The available hooks are:
 - [pre-proxy-reboot](../pre-proxy-reboot)
 - [post-proxy-reboot](../post-proxy-reboot)
 
-You can pass `--skip_hooks` to avoid running the hooks.
+You can pass `--skip-hooks` to avoid running the hooks.
 
 **Note:** The hook filename must be the hook name without any extension. For example, the [pre-deploy](../pre-deploy) hook should be named "pre-deploy" (without any file extension such as .sh or .rb).
+
+**Note:** Avoid running `kamal` commands from a [pre-connect](../pre-connect) hook. Since `pre-connect` runs before nearly every command, a nested `kamal` call will re-trigger it and recurse infinitely. See [pre-connect](../pre-connect) for details and how to guard against it.

--- a/docs/hooks/pre-connect.md
+++ b/docs/hooks/pre-connect.md
@@ -5,3 +5,24 @@ title: pre-connect
 # Hooks: pre-connect
 
 Runs before taking the deploy lock. For anything that needs to run before connecting to remote hosts, e.g., DNS warming, checking if you are on the VPN.
+
+This hook runs before Kamal connects to your servers, which happens for nearly every command — including `kamal app exec`.
+
+**Warning:** Do not run a `kamal` command from a `pre-connect` hook. Because `pre-connect` fires before connecting, the nested `kamal` command will trigger `pre-connect` again, which runs the hook again, and so on — resulting in infinite recursion.
+
+If you must invoke `kamal` from this hook (for example, to read secrets or check state), guard the script against re-entrancy. A simple approach is to set an environment marker and short-circuit when it is already present:
+
+```bash
+#!/bin/sh
+
+# Avoid infinite recursion: pre-connect runs before nearly every kamal command,
+# so calling kamal here would re-trigger this hook.
+if [ -n "$KAMAL_IN_PRE_CONNECT" ]; then
+  exit 0
+fi
+export KAMAL_IN_PRE_CONNECT=1
+
+# ... your logic that may call kamal ...
+```
+
+Alternatively, pass `--skip-hooks` to any nested `kamal` invocation so it does not run the hook again.


### PR DESCRIPTION
## What

Adds a warning to the `pre-connect` hook docs (and a short cross-reference in the hooks overview) about a re-entrancy/recursion footgun.

## Why

`pre-connect` runs before Kamal connects to your servers, which happens for nearly every command — including `kamal app exec`. People naturally reach for calling `kamal` from this hook (to read secrets, check state, etc.), but doing so recurses infinitely: the nested `kamal` command triggers `pre-connect` again, which runs the hook again, and so on. There is no obvious error explaining what happened, so it's easy to fall into.

This was verified against the Kamal source:

- `lib/kamal/cli/base.rb` runs the hook in `pre_connect_if_required`, which is invoked from `on(...)` (the SSHKit connect path) and is also called explicitly by `kamal app exec`. The `KAMAL.connected?` guard that prevents re-running it lives on the per-process `Commander` instance (`lib/kamal/commander.rb`, `connected` defaults to `false`), so a nested `kamal` invocation is a fresh process that starts with `connected = false` and runs the hook again.
- `lib/kamal/commands/hook.rb` confirms the hook is simply executed as a local script.

## Change

- `docs/hooks/pre-connect.md`: notes that the hook fires before connecting (so it runs for nearly every command, incl. `kamal app exec`), warns that calling `kamal` from the hook recurses infinitely, and gives guidance — avoid it, or guard against re-entrancy with an environment marker (example included), or pass `--skip-hooks` to nested invocations.
- `docs/hooks/overview.md`: one-line note pointing to the pre-connect page.

Docs-only change; matches the existing `**Note:**` / `**Warning:**` markdown style used elsewhere in the docs.
